### PR TITLE
Pull the `Map` library from `github:savi-lang/Map`.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -1,7 +1,8 @@
 :manifest lib Spec
   :sources "src/*.savi"
 
-  :dependency Map v0 // TODO: :from "github:savi-lang/Map"
+  :dependency Map v0
+    :from "github:savi-lang/Map"
 
 :manifest bin "spec"
   :copies Spec


### PR DESCRIPTION
Using no `:from` clause on a dependency is deprecated,
and all standard library packages are moving to their own repos.