### PR TITLE
Allow any type that holds the `Spec.Context` to use `assert:`.

### DIFF
--- a/spec/Spec.Assert.Spec.savi
+++ b/spec/Spec.Assert.Spec.savi
@@ -60,3 +60,12 @@
     assert error: map["example"]!
 
     assert error: _MaybeError.yes!
+
+  :it "can be called from another type that holds the spec context"
+    _OtherTypeThatCanAssert.new(@ctx)
+
+:class _OtherTypeThatCanAssert
+  :is Spec.Context.Holder
+  :let ctx Spec.Context
+  :new (@ctx)
+  :fun assert_something: assert: True

--- a/src/Spec.Assert.savi
+++ b/src/Spec.Assert.savi
@@ -9,11 +9,11 @@
   :fun print_failure(env Env) None
 
   :fun non condition(
-    spec Spec
+    caller Spec.Context.Holder
     success Bool
-    pos SourceCodePosition = source_code_position_of_argument spec
+    pos SourceCodePosition = source_code_position_of_argument caller
   )
-    ctx = spec.ctx
+    ctx = caller.ctx
     assert = Spec.Assert.Condition.new(
       ctx.spec
       ctx.example
@@ -23,14 +23,14 @@
     ctx.process.enqueue(assert)
 
   :fun non relation(
-    spec Spec
+    caller Spec.Context.Holder
     op String
     lhs Any'box
     rhs Any'box
     success Bool
-    pos SourceCodePosition = source_code_position_of_argument spec
+    pos SourceCodePosition = source_code_position_of_argument caller
   )
-    ctx = spec.ctx
+    ctx = caller.ctx
     assert = Spec.Assert.Relation.new(
       ctx.spec
       ctx.example
@@ -43,14 +43,14 @@
     ctx.process.enqueue(assert)
 
   :fun non type_relation(
-    spec Spec
+    caller Spec.Context.Holder
     op String
     lhs Any'box
     rhs String
     success Bool
-    pos SourceCodePosition = source_code_position_of_argument spec
+    pos SourceCodePosition = source_code_position_of_argument caller
   )
-    ctx = spec.ctx
+    ctx = caller.ctx
     assert = Spec.Assert.TypeRelation.new(
       ctx.spec
       ctx.example
@@ -63,12 +63,12 @@
     ctx.process.enqueue(assert)
 
   :fun non has_error(
-    spec Spec
+    caller Spec.Context.Holder
     has_error Bool
     expects_error Bool
-    pos SourceCodePosition = source_code_position_of_argument spec
+    pos SourceCodePosition = source_code_position_of_argument caller
   )
-    ctx = spec.ctx
+    ctx = caller.ctx
     assert = Spec.Assert.HasError.new(
       ctx.spec
       ctx.example

--- a/src/Spec.Context.savi
+++ b/src/Spec.Context.savi
@@ -4,3 +4,6 @@
   :let spec String
   :let example String
   :new (@env, @process, @spec, @example)
+
+:trait box Spec.Context.Holder
+  :fun ctx Spec.Context


### PR DESCRIPTION
Prior to this, only an instance of a `Spec` could use `assert:`,
but now any subtype of `Spec.Context.Holder'box` can assert.

This opens the door to asynchronously evaluated assertions,
by passing the `Spec.Context` into an actor.