### PR TITLE
Remove the `Spec.Event` class; `Spec.Assert` has all the info we need.

### DIFF
--- a/src/Spec.Event.savi
+++ b/src/Spec.Event.savi
@@ -1,9 +1,0 @@
-:class val Spec.Event
-  :let success Bool
-  :let pos SourceCodePosition
-  :let assert (Spec.Assert | None)
-
-  // TODO: refactor into the line below after #102 is fixed.
-  // :new (@success, @pos, @assert = None)
-  :new (@success, @pos, assert (Spec.Assert | None) = None)
-    @assert = assert

--- a/src/Spec.Process.savi
+++ b/src/Spec.Process.savi
@@ -61,32 +61,12 @@
       _Log.bug(@env, "example_ended before the example_began")
     )
 
-  :be assert(spec String, example String, success Bool, pos SourceCodePosition)
-    event = Spec.Event.new(success, pos)
+  :be enqueue(event Spec.Assert)
+    spec = event.spec
+    example = event.example
 
     // If it was a failed assertion, mark the entire process as a failure.
-    if success.not _Log.fail(@env)
-
-    try (
-      @statuses[spec]!.examples[example]!.events << event
-      @reporter.event(spec, example, event)
-    |
-      _Log.bug(@env, "assert before the example_began and/or spec_began")
-    )
-
-  // TODO: This behavior is a copy of the `:be assert` above.
-  // I added it to keep `@assert =` working while implementing the `assert` macro.
-  // In the end we won't need both of them, after we clean up `@assert =`.
-  :be enqueue(assert Spec.Assert)
-    spec = assert.spec
-    example = assert.example
-    success = assert.success
-
-    // TODO: refactor to `Spec.Event.new(assert)`
-    event = Spec.Event.new(success, assert.pos, assert)
-
-    // If it was a failed assertion, mark the entire process as a failure.
-    if !success _Log.fail(@env)
+    if !event.success _Log.fail(@env)
 
     try (
       @statuses[spec]!.examples[example]!.events << event

--- a/src/Spec.Reporter.savi
+++ b/src/Spec.Reporter.savi
@@ -3,7 +3,7 @@
   :fun ref spec_ended(spec String): None
   :fun ref example_began(spec String, example String): None
   :fun ref example_ended(spec String, example String, skip Bool): None
-  :fun ref event(spec String, example String, event Spec.Event): None
+  :fun ref event(spec String, example String, event Spec.Assert): None
 
 :class Spec.Reporter.Dots
   :is Spec.Reporter
@@ -16,7 +16,7 @@
   :fun ref example_began(spec String, example String)
     @env.err.write(" ")
 
-  :fun ref event(spec String, example String, event Spec.Event)
+  :fun ref event(spec String, example String, event Spec.Assert)
     if event.success (
       @env.err.write(".")
     |
@@ -45,18 +45,11 @@
   :fun ref example_ended(spec String, example String, skip Bool)
     if skip (@env.err.print(" SKIP") | @env.err.print(" OK"))
 
-  :fun ref event(spec String, example String, event Spec.Event)
+  :fun ref event(spec String, example String, event Spec.Assert)
     if event.success (
       @env.err.write(".")
     |
-      try (
-        event.assert.as!(Spec.Assert).print_failure(@env)
-      |
-        @env.err.write("\n")
-        @env.err.write(Inspect[event.pos.row + 1])
-        @env.err.write(": FAIL: ")
-        @env.err.print(event.pos.string)
-      )
+      event.print_failure(@env)
     )
 
 :class Spec.Reporter.Linear
@@ -71,7 +64,7 @@
   :fun ref spec_ended(spec String): @_changed
   :fun ref example_began(spec String, example String): @_changed
   :fun ref example_ended(spec String, example String, skip Bool): @_changed
-  :fun ref event(spec String, example String, event Spec.Event): @_changed
+  :fun ref event(spec String, example String, event Spec.Assert): @_changed
 
   :fun ref _changed None // TODO: be able to infer return type for maybe-recursive functions
     // If no spec and example are selected for linear reporting, pick them now.

--- a/src/Spec.Status.savi
+++ b/src/Spec.Status.savi
@@ -7,7 +7,7 @@
   :new (@name)
 
 :class Spec.Status.ForExample
-  :let events: Array(Spec.Event).new
+  :let events: Array(Spec.Assert).new
   :var events_reported USize: 0
   :let name String
   :var ended Bool: False


### PR DESCRIPTION
After all the refactoring of how assertions work, `Spec.Assert`
now contains everything that was held by `Spec.Event` (and more)
so there is no reason to keep `Spec.Event` around as a wrapper for
`Spec.Assert`.