### PR TITLE
Rename `event` to `assertion` throughout the code (including plural f…

### DIFF
--- a/src/Spec.Process.savi
+++ b/src/Spec.Process.savi
@@ -104,7 +104,7 @@
       example_status.is_ended = True
       example_status._runner.dispose
 
-      stats = Spec.Statistics.ForExample.from_events(example_status.events)
+      stats = Spec.Statistics.ForExample.from_assertions(example_status.assertions)
       @reporter.example_ended(spec, example, stats)
 
       if (
@@ -117,17 +117,17 @@
       @env.bug("example_ended before the example_began")
     )
 
-  :be enqueue(event Spec.Assert)
-    spec = event.spec
-    example = event.example
+  :be enqueue(assertion Spec.Assert)
+    spec = assertion.spec
+    example = assertion.example
 
     // If it was a failed assertion, mark the entire process as a failure.
-    if !event.success @env.fail
+    if !assertion.success @env.fail
 
     try (
       status = @statuses[spec]!.examples[example]!
-      status.events << event
-      @reporter.event(spec, example, event)
+      status.assertions << assertion
+      @reporter.assertion(spec, example, assertion)
       if status.is_ready_to_end @_example_ended(spec, example)
     |
       @env.bug("assert before the example_began and/or spec_began")

--- a/src/Spec.Reporter.savi
+++ b/src/Spec.Reporter.savi
@@ -7,7 +7,7 @@
   :fun ref example_ended(spec String, example String, stats Spec.Statistics.ForExample): None
   :fun ref example_timed_ping(spec String, example String): None
   :fun ref example_timed_out(spec String, example String): None
-  :fun ref event(spec String, example String, event Spec.Assert): None
+  :fun ref assertion(spec String, example String, assertion Spec.Assert): None
 
 :class Spec.Reporter.Dots
   :is Spec.Reporter
@@ -21,19 +21,19 @@
   :fun ref example_began(spec String, example String)
     @env.write_err(" ")
 
-  :fun ref event(spec String, example String, event Spec.Assert)
-    if event.success (
+  :fun ref assertion(spec String, example String, assertion Spec.Assert)
+    if assertion.success (
       @env.write_err(".")
     |
       @env.print_err("\nFAIL: \(spec) \(example)")
-      @env.print_err("  X \(event.pos.string)")
+      @env.print_err("  X \(assertion.pos.string)")
     )
 
 :class Spec.Reporter.Full
   :is Spec.Reporter
   :let env Spec.Env
   :let statuses Map.Ordered(String, Spec.Status)
-  :let failed_events: Array(Spec.Assert).new
+  :let failed_assertions: Array(Spec.Assert).new
 
   :new (@env, @statuses)
 
@@ -48,14 +48,14 @@
 
   :fun ref example_ended(spec String, example String, stats Spec.Statistics.ForExample)
     msg = case (
-    | stats.failed_events > 0 | @_red("FAIL")
-    | stats.passed_events > 0 | @_green("OK")
+    | stats.failed_assertions > 0 | @_red("FAIL")
+    | stats.passed_assertions > 0 | @_green("OK")
     |                           "SKIP"
     )
     @env.print_err(" \(--msg)")
 
-    @failed_events.each -> (event |
-      @env.print_err(String.join(event.format_failure, "\n"))
+    @failed_assertions.each -> (assertion |
+      @env.print_err(String.join(assertion.format_failure, "\n"))
     )
 
   :var colorize Bool: True
@@ -71,25 +71,25 @@
       --s
     )
 
-  :fun ref event(spec String, example String, event Spec.Assert) None
-    if event.success (
+  :fun ref assertion(spec String, example String, assertion Spec.Assert) None
+    if assertion.success (
       @env.write_err(".")
     |
       @env.write_err("F")
-      @failed_events << event
+      @failed_assertions << assertion
     )
 
   :fun ref example_timed_ping(spec String, example String)
-    @_print_waiting_action_events("waiting for action", spec, example)
+    @_print_waiting_action_assertions("waiting for action", spec, example)
 
   :fun ref example_timed_out(spec String, example String)
-    @_print_waiting_action_events("Timed out waiting for action", spec, example)
+    @_print_waiting_action_assertions("Timed out waiting for action", spec, example)
 
-  :fun _print_waiting_action_events(msg String, spec String, example String)
+  :fun _print_waiting_action_assertions(msg String, spec String, example String)
     try (
       status = @statuses[spec]!.examples[example]!
-      status.each_waiting_action_event -> (event |
-        @env.print_out("\n    \(msg): \(event.action)\n    \(event.file_and_line)")
+      status.each_waiting_action_assertion -> (assertion |
+        @env.print_out("\n    \(msg): \(assertion.action)\n    \(assertion.file_and_line)")
       )
     |
       @env.bug("no status for this example")
@@ -119,7 +119,7 @@
   :fun ref spec_ended(spec String): @_changed
   :fun ref example_began(spec String, example String): @_changed
   :fun ref example_ended(spec String, example String, stats Spec.Statistics.ForExample): @_changed
-  :fun ref event(spec String, example String, event Spec.Assert): @_changed
+  :fun ref assertion(spec String, example String, assertion Spec.Assert): @_changed
 
   :fun ref example_timed_ping(spec String, example String)
     @_changed
@@ -141,7 +141,7 @@
     // Now report on the selected example and spec. This has to be done in this
     // order, since examples in the spec need to be reported before reporting
     // the end of the spec. Both of these functions are potentially recursive,
-    // in the event that the example or spec is finished and we need to pick
+    // in the assertion that the example or spec is finished and we need to pick
     // new ones to continue reporting more about changes to the statuses.
     if @current_example.is_not_empty @_report_examples_from_current
     if @current_spec   .is_not_empty @_report_specs_from_current
@@ -181,20 +181,20 @@
     try (
       example_status = @statuses[@current_spec]!.examples[@current_example]!
 
-      // Any events that have arrived for this example, but have not yet
+      // Any assertions that have arrived for this example, but have not yet
       // been reported should be reported now, tracking how many we've done.
-      while (example_status.events_reported < example_status.events.size) (
+      while (example_status.assertions_reported < example_status.assertions.size) (
         try (
-          event = example_status.events[example_status.events_reported]!
-          @inner.event(@current_spec, @current_example, event)
+          assertion = example_status.assertions[example_status.assertions_reported]!
+          @inner.assertion(@current_spec, @current_example, assertion)
         )
-        example_status.events_reported += 1
+        example_status.assertions_reported += 1
       )
 
       if example_status.is_ended (
         // If the example has finished, but has not yet been reported, report now.
         if !example_status.is_reported (
-          stats = Spec.Statistics.ForExample.from_events(example_status.events)
+          stats = Spec.Statistics.ForExample.from_assertions(example_status.assertions)
           @inner.example_ended(@current_spec, @current_example, stats)
           example_status.is_reported = True
         )

--- a/src/Spec.Statistics.savi
+++ b/src/Spec.Statistics.savi
@@ -1,23 +1,21 @@
 :struct Spec.Statistics.ForExample
-  :let total_events USize
-  :let failed_events USize
-  :let passed_events USize 
+  :let total_assertions USize
+  :let failed_assertions USize
+  :let passed_assertions USize
 
-  :new(@total_events, @failed_events, @passed_events)
+  :new(@total_assertions, @failed_assertions, @passed_assertions)
 
-  :new from_events(events Array(Spec.Assert))
-    @total_events = events.size
-    passed_events = 0  
-    failed_events = 0
-    events.each -> (event |
-      if event.success (
-        passed_events = passed_events + 1
+  :new from_assertions(assertions Array(Spec.Assert))
+    @total_assertions = assertions.size
+    passed_assertions = 0
+    failed_assertions = 0
+    assertions.each -> (assertion |
+      if assertion.success (
+        passed_assertions = passed_assertions + 1
       |
-        failed_events = failed_events + 1
+        failed_assertions = failed_assertions + 1
       )
     )
-    @passed_events = passed_events
-    @failed_events = failed_events
-
-
+    @passed_assertions = passed_assertions
+    @failed_assertions = failed_assertions
 

--- a/src/Spec.Status.savi
+++ b/src/Spec.Status.savi
@@ -9,8 +9,8 @@
 :class Spec.Status.ForExample
   :let name String
   :let _runner _Runner.Any
-  :let events: Array(Spec.Assert).new
-  :var events_reported USize: 0
+  :let assertions: Array(Spec.Assert).new
+  :var assertions_reported USize: 0
   :var is_synchronous_portion_ended Bool: False
   :var is_ended Bool: False
   :var is_reported Bool: False
@@ -24,14 +24,14 @@
 
   :fun _waiting_action_counts
     counts = Map(String, I32).new
-    @events.each -> (event |
-      case event <: (
+    @assertions.each -> (assertion |
+      case assertion <: (
       | Spec.Assert.WaitForAction |
         // TODO: A more streamlined method in Map for doing this "upsert":
-        counts[event.action] = try (counts[event.action]! + 1 | 1)
+        counts[assertion.action] = try (counts[assertion.action]! + 1 | 1)
       | Spec.Assert.FinishedAction |
         // TODO: A more streamlined method in Map for doing this "upsert":
-        counts[event.action] = try (counts[event.action]! - 1 | -1)
+        counts[assertion.action] = try (counts[assertion.action]! - 1 | -1)
       )
     )
     counts
@@ -39,18 +39,18 @@
   :fun has_any_waiting_actions
     @_waiting_action_counts.has_any -> (action, count | count > 0)
 
-  :fun each_waiting_action_event
+  :fun each_waiting_action_assertion
     :yields Spec.Assert.WaitForAction for None
     counts = @_waiting_action_counts
     counts.each -> (action, count |
       next if (count <= 0)
 
       yielded_count = 0
-      @events.reverse_each -> (event |
-        if (event <: Spec.Assert.WaitForAction) (
-          next unless (event.action == action)
+      @assertions.reverse_each -> (assertion |
+        if (assertion <: Spec.Assert.WaitForAction) (
+          next unless (assertion.action == action)
 
-          yield event
+          yield assertion
 
           yielded_count += 1
           break if (yielded_count == count)


### PR DESCRIPTION
…orms)

Reflecting the change introduced in [PR #10][pr-10] which replaced `Spec.Event` by `Spec.Assert`.

We should actually also rename `Spec.Assert` to `Spec.Assertion` or is `Assert` a noun?

[pr-10]: https://github.com/savi-lang/Spec/pull/10