### PR TITLE
Print root-package relative path of the file where a failure happens

### DIFF
--- a/spec/Spec.Process.Spec.savi
+++ b/spec/Spec.Process.Spec.savi
@@ -63,7 +63,7 @@
       ""
       "    Expected to be True"
       ""
-      "    # Spec.Process.Spec.savi: 45"
+      "    # spec/Spec.Process.Spec.savi: 45"
       ""
       ""
     ], "\n")

--- a/src/Spec.Assert.savi
+++ b/src/Spec.Assert.savi
@@ -80,7 +80,7 @@
 
   :fun file_and_line String
     line = @pos.row + 1
-    "# \(@pos.filename): \(line.format.decimal)"
+    "# \(@pos.filepath_rootpkgrel): \(line.format.decimal)"
 
   :fun indent(times USize, msg String) String
     String.join([" " * times, msg])


### PR DESCRIPTION
Issue #20 is about printing the absolute path and not the package-relative path as this commit implements. We decided to use the root-package relative path as the absolute path exposes details about where you store your files and also makes the spec for `Spec` itself difficult.

The root-package is the one where you are running `savi build` or `savi run` from.

This requires savi v0.20220921.1 or later.

Related issues: #20