### PR TITLE
Print a final statistic

### DIFF
--- a/spec/Spec.Process.Spec.savi
+++ b/spec/Spec.Process.Spec.savi
@@ -34,7 +34,14 @@
   :be capture_report(err String, out String, exitcode I32)
     assert: exitcode == 0
     assert: out == ""
-    assert: err == "_SpecThatSucceeds\n  succeeds . \x1b[32mOK\x1b[0m\n\n"
+    assert: err == String.join([
+      "_SpecThatSucceeds"
+      "  succeeds . \x1b[32mOK\x1b[0m"
+      ""
+      "test result: \x1b[32mOK\x1b[0m. 1 passed; 0 failed; finished in 0s"
+      ""
+    ], "\n")
+
     @ctx.finished_action("capture.ok")
 
 :class _SpecThatFails
@@ -63,8 +70,9 @@
       ""
       "    Expected to be True"
       ""
-      "    # spec/Spec.Process.Spec.savi: 45"
+      "    # spec/Spec.Process.Spec.savi: 52"
       ""
+      "test result: \x1b[31mFAIL\x1b[0m. 0 passed; 1 failed; finished in 0s"
       ""
     ], "\n")
 

--- a/src/Spec.Process.savi
+++ b/src/Spec.Process.savi
@@ -12,6 +12,7 @@
     @reporter = Spec.Reporter.Linear.new(@env, @statuses
       Spec.Reporter.Full.new(@env, @statuses)
     )
+    @overall_began
 
   :fun non _run(env Spec.Env, runners Array(Spec.Run.Any)) // TODO: shouldn't need this indirection
     process = @_new(env, runners.size)
@@ -52,6 +53,7 @@
     status.expected_examples = expected_examples
     @statuses[spec] = status
     @reporter.spec_began(spec)
+
 
   :fun ref overall_began
     @reporter.overall_began

--- a/src/Spec.Reporter.savi
+++ b/src/Spec.Reporter.savi
@@ -36,7 +36,6 @@
   :let failed_assertions: Array(Spec.Assert).new
 
   :var _overall_began U64: 0
-  :var _num_total_examples USize: 0
   :var _num_total_assertions USize: 0
   :var _num_failed_assertions USize: 0
 
@@ -69,7 +68,6 @@
     @env.write_err("  \(example) ")
 
   :fun ref example_ended(spec String, example String, stats Spec.Statistics.ForExample)
-    @_num_total_examples = @_num_total_examples + 1
     @_num_total_assertions = @_num_total_assertions + stats.total_assertions
     @_num_failed_assertions = @_num_failed_assertions + stats.failed_assertions
 

--- a/src/Spec.Reporter.savi
+++ b/src/Spec.Reporter.savi
@@ -35,6 +35,11 @@
   :let statuses Map.Ordered(String, Spec.Status)
   :let failed_assertions: Array(Spec.Assert).new
 
+  :var _overall_began U64: 0
+  :var _num_total_examples USize: 0
+  :var _num_total_assertions USize: 0
+  :var _num_failed_assertions USize: 0
+
   :new (@env, @statuses)
 
   :fun ref spec_began(spec String)
@@ -43,14 +48,35 @@
   :fun ref spec_ended(spec String)
     @env.print_err("") // just a newline
 
+  :fun ref overall_began
+    @_overall_began = Time.Measure.current_milliseconds
+    None
+
+  :fun ref overall_ended
+    elapsed_s = (Time.Measure.current_milliseconds - @_overall_began) / 1000
+
+    msg = case (
+    | @_num_failed_assertions > 0 | @_red("FAIL")
+    |                               @_green("OK")
+    )
+    num_passed = @_num_total_assertions - @_num_failed_assertions
+
+    @env.print_err("test result: \(--msg). \(num_passed) passed; \(@_num_failed_assertions) failed; finished in \(elapsed_s.format.decimal)s")
+    None
+
   :fun ref example_began(spec String, example String)
+    @failed_assertions.clear
     @env.write_err("  \(example) ")
 
   :fun ref example_ended(spec String, example String, stats Spec.Statistics.ForExample)
+    @_num_total_examples = @_num_total_examples + 1
+    @_num_total_assertions = @_num_total_assertions + stats.total_assertions
+    @_num_failed_assertions = @_num_failed_assertions + stats.failed_assertions
+
     msg = case (
     | stats.failed_assertions > 0 | @_red("FAIL")
     | stats.passed_assertions > 0 | @_green("OK")
-    |                           "SKIP"
+    |                               "SKIP"
     )
     @env.print_err(" \(--msg)")
 
@@ -60,11 +86,11 @@
 
   :var colorize Bool: True
 
-  :fun _red(s String): @_fg_color(s, _FgColor.Red)
+  :fun _red(s String'val): @_fg_color(s, _FgColor.Red)
 
-  :fun _green(s String): @_fg_color(s, _FgColor.Green)
+  :fun _green(s String'val): @_fg_color(s, _FgColor.Green)
 
-  :fun _fg_color(s String, color _FgColor): String
+  :fun _fg_color(s String'val, color _FgColor): String
     if @colorize (
       "\(color.ansi)\(s)\x1b[0m"
     |


### PR DESCRIPTION
Prints a final statistic similar to the following:

```
test result: OK. 39 passed; 0 failed; finished in 0s
```

Inspired by `cargo test` statistics. If it's worth, we can also show number of examples.

Related issues: #16
