### PR TITLE
Remove usage of `*_until`-style iteration methods.

### DIFF
--- a/src/Spec.Reporter.savi
+++ b/src/Spec.Reporter.savi
@@ -187,34 +187,31 @@
 
   :fun ref _choose_next_spec Bool
     // Find the name of the first spec whose status is not yet reported.
-    @statuses.each_until -> (spec, status |
+    @statuses.each -> (spec, status |
       if status.is_reported.not (
         @current_spec = spec
         @current_example = ""
         @inner.spec_began(@current_spec)
-        True
-      |
-        False
+        return True
       )
     )
+    False
 
   :fun ref _choose_next_example Bool
     // Find the name of the first example in this spec that is not yet reported.
     try (
       status = @statuses[@current_spec]!
-      status.examples.each_until -> (example, example_status |
+      status.examples.each -> (example, example_status |
         if example_status.is_reported.not (
           @current_example = example
           @inner.example_began(@current_spec, @current_example)
-          True
-        |
-          False
+          return True
         )
       )
     |
       @_effects.bug("no status for current_spec")
-      False
     )
+    False
 
   :fun ref _report_examples_from_current None // TODO: be able to infer return type for maybe-recursive functions
     try (


### PR DESCRIPTION
This style/convention is a legacy from an old version of the Savi language, in which yield blocks could not be "jumped out of".

Now that `return`, `error!`, and `break` can all jump out of a yield block, the pattern (of allowing the caller to yield back a `Bool` to indicate whether iteration should continue) is obsolete, and should be removed to reduce complexity and maintenance burden.